### PR TITLE
Add support for SIGTSTP

### DIFF
--- a/lsignal.c
+++ b/lsignal.c
@@ -103,6 +103,9 @@ static const struct lua_signal lua_signals[] = {
 #ifdef SIGSTOP
   {"SIGSTOP", SIGSTOP},
 #endif
+#ifdef SIGTSTP
+  {"SIGTSTP", SIGTSTP},
+#endif
 #ifdef SIGTTIN
   {"SIGTTIN", SIGTTIN},
 #endif


### PR DESCRIPTION
SIGTSTP is the signal received when the user sends Ctrl-Z from the
terminal. It is different from SIGSTOP, and was not yet supported by
lua-signal. This pull-requests adds it.

Example use:

``` lua
require 'signal'
require 'sys' -- for sleep

signal.signal('SIGTSTP', function() print('HELLO WORLD!') end)

while true do
    print('...')
    sys.sleep(1)
end
```
